### PR TITLE
fixes set_sizes_contiguous runtime error for newer pytorch versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Model parameters
+demo.pth

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -134,4 +134,17 @@ class averager(object):
         return res
 
 def loadData(v, data):
-    v.data.resize_(data.size()).copy_(data)
+    major, _ = get_torch_version()
+
+    if major >= 1:
+        v.resize_(data.size()).copy_(data)
+    else:
+        v.data.resize_(data.size()).copy_(data)
+
+def get_torch_version():
+    """
+    Find pytorch version and return it as integers
+    for major and minor versions
+    """
+    torch_version = str(torch.__version__).split(".")
+    return int(torch_version[0]), int(torch_version[1])


### PR DESCRIPTION
Older versions of pytorch are not readily available, so I ended up using a new version which supports newer CUDA drivers I was using. I came across this error:
`RuntimeError: set_sizes_contiguous is not allowed on Tensor created from .data or .detach()`
I fixed this error in the following file:
`\tools\utils.py`
by adding a function to get pytorch version and if the major version is 1 or above, the `.data` is not used anymore. I hope this helps!